### PR TITLE
get rid of deprecated calls for redis

### DIFF
--- a/src/Backend/RedisCache.php
+++ b/src/Backend/RedisCache.php
@@ -9,7 +9,7 @@ use Redis;
 
 /**
  * Class RedisCache
- * 
+ *
  * A redis powered backend for caching
  *
  * @package Cmp\Cache\Infrastureture\Backend
@@ -118,7 +118,7 @@ class RedisCache extends TaggableCache
      */
     public function delete($key)
     {
-        return (bool) $this->client->delete($key);
+        return (bool) $this->client->del($key);
     }
 
     /**
@@ -126,7 +126,7 @@ class RedisCache extends TaggableCache
      */
     public function deleteItems(array $keys)
     {
-        return call_user_func_array([$this->client, 'delete'], $keys) > 0;
+        return call_user_func_array([$this->client, 'del'], $keys) > 0;
     }
 
     /**
@@ -160,6 +160,6 @@ class RedisCache extends TaggableCache
     {
         $timeToLive = $this->client->ttl($key);
 
-        return false === $timeToLive || $timeToLive <= 0 ? null : $timeToLive; 
+        return false === $timeToLive || $timeToLive <= 0 ? null : $timeToLive;
     }
 }

--- a/tests/spec/Backend/RedisCacheSpec.php
+++ b/tests/spec/Backend/RedisCacheSpec.php
@@ -58,14 +58,14 @@ class RedisCacheSpec extends ObjectBehavior
 
     function it_delete_an_item(Redis $redis)
     {
-        $redis->delete('foo')->willReturn(true);
+        $redis->del('foo')->willReturn(true);
 
         $this->delete('foo')->shouldReturn(true);
     }
 
     function it_delete_multiple_items_at_once(Redis $redis)
     {
-        $redis->delete(['foo', 'bar'])->willReturn(true);
+        $redis->del(['foo', 'bar'])->willReturn(true);
 
         $this->delete(['foo', 'bar'])->shouldReturn(true);
     }
@@ -109,7 +109,7 @@ class RedisCacheSpec extends ObjectBehavior
 
     function it_deletes_multiple_items_from_cache(Redis $redis)
     {
-        $redis->delete('foo', 'bar')->willReturn(2);
+        $redis->del('foo', 'bar')->willReturn(2);
 
         $this->deleteItems(['foo', 'bar'])->shouldReturn(true);
     }


### PR DESCRIPTION
Redis::delete method was deprecated [(link),](https://github.com/phpredis/phpredis/blob/develop/Changelog.md#deprecated) so would be good to start to use del method instead